### PR TITLE
Revert "ci: set initial release as v0.14.0"

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,7 +12,5 @@ jobs:
         with:
           release-type: go
           package-name: terraform-registry
-          # Remove after first release
-          release-as: v0.14.0
           # Before we are at v1
           bump-minor-pre-major: true


### PR DESCRIPTION
This reverts commit edc3832ffcfc7f785231531c75638df62c932990.

After this PR, release will work as intended, bumping version from 0.14 and onwards!