### PR TITLE
ci: bump minor for minor and major changes before v1

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "go",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "draft-pull-request": true,
       "prerelease": false


### PR DESCRIPTION
Let's keep the system as it has been up until now. Minor changes should also just bump the minor before v1 is reached, just like major changes. Patch changes still only bump patch.