### PR TITLE
ci: run dependabot for gomods weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
     timezone: "Europe/Oslo"
   commit-message:


### PR DESCRIPTION
AWS SDK has a new release almost daily. This is too much of a spam factor right now. Hopefully we can mitigate this in another way some day, but for now I think this is the best way to go.