### PR TITLE
ci: fix binary upload script

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -56,5 +56,5 @@ jobs:
 
           make LD_FLAGS="${LD_FLAGS}" build
           tar -cvzf terraform-registry.tar.gz terraform-registry
-          gh release upload ${VERSION} terraform-registry.tar.gz%#%terraform-registry_${VERSION}_${GOOS}_${GOARCH}.tar.gz
+          gh release upload ${VERSION} "terraform-registry.tar.gz#terraform-registry_${VERSION}_${GOOS}_${GOARCH}.tar.gz"
           rm terraform-registry terraform-registry.tar.gz

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -53,8 +53,8 @@ jobs:
           LD_FLAGS+=" -w" # no DWARF debug info
           LD_FLAGS+=" -X 'main.buildDate=$(date --utc +%Y-%m-%dT%H:%M:%SZ)'"
           LD_FLAGS+=" -X 'main.version=${VERSION}'"
+          ARCHIVE_NAME="terraform-registry_${VERSION}_${GOOS}_${GOARCH}.tar.gz"
 
           make LD_FLAGS="${LD_FLAGS}" build
-          tar -cvzf terraform-registry.tar.gz terraform-registry
-          gh release upload ${VERSION} "terraform-registry.tar.gz#terraform-registry_${VERSION}_${GOOS}_${GOARCH}.tar.gz"
-          rm terraform-registry terraform-registry.tar.gz
+          tar -cvzf "${ARCHIVE_NAME}" terraform-registry
+          gh release upload ${VERSION} "${ARCHIVE_NAME}"


### PR DESCRIPTION
Upload would fail with

```
go build -ldflags "-s -w -X 'main.buildDate=2024-04-22T08:43:33Z' -X
'main.version=v0.20.0'"  -o ./terraform-registry
./cmd/terraform-registry
go: downloading github.com/aws/aws-sdk-go v1.51.22
go: downloading go.uber.org/zap v1.27.0
go: downloading github.com/go-chi/chi/v5 v5.0.12
go: downloading github.com/golang-jwt/jwt/v5 v5.2.1
go: downloading github.com/ProtonMail/go-crypto v1.0.0
go: downloading github.com/google/go-github/v43 v43.0.0
go: downloading github.com/hashicorp/go-version v1.6.0
go: downloading golang.org/x/oauth2 v0.18.0
go: downloading go.uber.org/multierr v1.10.0
go: downloading golang.org/x/crypto v0.21.0
go: downloading github.com/google/go-querystring v1.1.0
go: downloading github.com/cloudflare/circl v1.3.7
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading golang.org/x/sys v0.18.0
terraform-registry
stat terraform-registry.tar.gz%: no such file or directory
```