### PR TITLE
fix: better handle transient errors from the GH api

### DIFF
--- a/pkg/store/github/github.go
+++ b/pkg/store/github/github.go
@@ -35,6 +35,48 @@ type SHASum struct {
 	FileName string
 }
 
+// isTransientError returns true if the error is a transient API/network error
+// (e.g. bad credentials, rate limiting, server errors) that should not cause
+// a release to be permanently marked as invalid.
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var rateLimitErr *github.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return true
+	}
+
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		return true
+	}
+
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		code := ghErr.Response.StatusCode
+		if code == http.StatusUnauthorized || code == http.StatusForbidden || code >= http.StatusInternalServerError {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isRateLimitError returns true if the error is a GitHub rate limit or
+// abuse rate limit error. These should abort the entire reload since
+// subsequent API calls will also fail.
+func isRateLimitError(err error) bool {
+	var rateLimitErr *github.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return true
+	}
+
+	var abuseErr *github.AbuseRateLimitError
+	return errors.As(err, &abuseErr)
+}
+
 func parseSHASumsFile(r io.Reader) map[string]string {
 	sums := make(map[string]string)
 
@@ -234,8 +276,6 @@ func (s *GitHubStore) findAsset(ctx context.Context, owner string, repo string, 
 // Should be called at least once after initialisation and probably on regular
 // intervals afterward to keep providerCache up-to-date.
 func (s *GitHubStore) ReloadProviderCache(ctx context.Context) error {
-	var rateLimitErr *github.RateLimitError
-
 	repos, err := s.searchProviderRepositories(ctx)
 	if err != nil {
 		return err
@@ -281,8 +321,13 @@ func (s *GitHubStore) ReloadProviderCache(ctx context.Context) error {
 
 			SHASums, SHASumURL, SHASumFileName, err := s.getSHA256Sums(ctx, owner, name, release.Assets)
 			if err != nil {
-				if errors.As(err, &rateLimitErr) {
-					return err
+				if isTransientError(err) {
+					if isRateLimitError(err) {
+						s.logger.Error(fmt.Sprintf("rate limited processing release [%s/%s], aborting cache reload: %s", nameKey, version, err))
+						return err
+					}
+					s.logger.Warn(fmt.Sprintf("transient API error processing release [%s/%s], skipping: %s", nameKey, version, err))
+					continue
 				}
 				s.logger.Warn(fmt.Sprintf("not a valid release [%s/%s] - could not find SHA checksums: %s", nameKey, version, err))
 				s.providerIgnoreCache.Store(cacheKey(nameKey, version), true)
@@ -291,9 +336,6 @@ func (s *GitHubStore) ReloadProviderCache(ctx context.Context) error {
 
 			// not considered a valid release if a shasum file was not part of the release
 			if SHASumURL == "" {
-				if errors.As(err, &rateLimitErr) {
-					return err
-				}
 				s.logger.Warn(fmt.Sprintf("not a valid release [%s/%s] - could not find SHA checksums", nameKey, version))
 				s.providerIgnoreCache.Store(cacheKey(nameKey, version), true)
 				continue
@@ -301,8 +343,13 @@ func (s *GitHubStore) ReloadProviderCache(ctx context.Context) error {
 
 			providerProtocols, err := s.getProviderProtocols(ctx, owner, name, release.Assets)
 			if err != nil {
-				if errors.As(err, &rateLimitErr) {
-					return err
+				if isTransientError(err) {
+					if isRateLimitError(err) {
+						s.logger.Error(fmt.Sprintf("rate limited processing release [%s/%s], aborting cache reload: %s", nameKey, version, err))
+						return err
+					}
+					s.logger.Warn(fmt.Sprintf("transient API error processing release [%s/%s], skipping: %s", nameKey, version, err))
+					continue
 				}
 				s.logger.Warn(fmt.Sprintf("not a valid release [%s/%s] - unable to identify provider protocol", nameKey, version))
 				s.providerIgnoreCache.Store(cacheKey(nameKey, version), true)
@@ -311,8 +358,13 @@ func (s *GitHubStore) ReloadProviderCache(ctx context.Context) error {
 
 			keys, err := s.getGPGPublicKey(ctx, release, owner, name)
 			if err != nil || len(keys) != 1 {
-				if errors.As(err, &rateLimitErr) {
-					return err
+				if isTransientError(err) {
+					if isRateLimitError(err) {
+						s.logger.Error(fmt.Sprintf("rate limited processing release [%s/%s], aborting cache reload: %s", nameKey, version, err))
+						return err
+					}
+					s.logger.Warn(fmt.Sprintf("transient API error processing release [%s/%s], skipping: %s", nameKey, version, err))
+					continue
 				}
 				s.logger.Warn(fmt.Sprintf("not a valid release [%s/%s] - unable to get GPG Public Key", nameKey, version))
 				s.providerIgnoreCache.Store(cacheKey(nameKey, version), true)

--- a/pkg/store/github/github_test.go
+++ b/pkg/store/github/github_test.go
@@ -6,7 +6,9 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -201,6 +203,187 @@ func TestListModuleVersions(t *testing.T) {
 		is.Equal(versions, nil)
 	})
 
+}
+
+func Test_isTransientError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			transient: false,
+		},
+		{
+			name:      "generic error",
+			err:       fmt.Errorf("something went wrong"),
+			transient: false,
+		},
+		{
+			name: "rate limit error",
+			err: &github.RateLimitError{
+				Response: &http.Response{StatusCode: 403},
+				Message:  "rate limit exceeded",
+			},
+			transient: true,
+		},
+		{
+			name: "abuse rate limit error",
+			err: &github.AbuseRateLimitError{
+				Response: &http.Response{StatusCode: 403},
+				Message:  "abuse detection",
+			},
+			transient: true,
+		},
+		{
+			name: "401 unauthorized",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 401,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Bad credentials",
+			},
+			transient: true,
+		},
+		{
+			name: "403 forbidden",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 403,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Forbidden",
+			},
+			transient: true,
+		},
+		{
+			name: "500 internal server error",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 500,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Internal Server Error",
+			},
+			transient: true,
+		},
+		{
+			name: "502 bad gateway",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 502,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Bad Gateway",
+			},
+			transient: true,
+		},
+		{
+			name: "404 not found - not transient",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 404,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Not Found",
+			},
+			transient: false,
+		},
+		{
+			name: "422 unprocessable entity - not transient",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 422,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Validation Failed",
+			},
+			transient: false,
+		},
+		{
+			name:      "wrapped transient error",
+			err:       fmt.Errorf("download failed: %w", &github.ErrorResponse{Response: &http.Response{StatusCode: 401, Request: &http.Request{Method: "GET", URL: &url.URL{Path: "/test"}}}, Message: "Bad credentials"}),
+			transient: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransientError(tt.err)
+			if result != tt.transient {
+				t.Errorf("isTransientError() = %v, want %v for error: %v", result, tt.transient, tt.err)
+			}
+		})
+	}
+}
+
+func Test_isRateLimitError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		rateLimit bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			rateLimit: false,
+		},
+		{
+			name:      "generic error",
+			err:       fmt.Errorf("something went wrong"),
+			rateLimit: false,
+		},
+		{
+			name: "rate limit error",
+			err: &github.RateLimitError{
+				Response: &http.Response{StatusCode: 403},
+				Message:  "rate limit exceeded",
+			},
+			rateLimit: true,
+		},
+		{
+			name: "abuse rate limit error",
+			err: &github.AbuseRateLimitError{
+				Response: &http.Response{StatusCode: 403},
+				Message:  "abuse detection",
+			},
+			rateLimit: true,
+		},
+		{
+			name: "401 unauthorized - not a rate limit",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 401,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Bad credentials",
+			},
+			rateLimit: false,
+		},
+		{
+			name: "500 server error - not a rate limit",
+			err: &github.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 500,
+					Request:    &http.Request{Method: "GET", URL: &url.URL{Path: "/repos/test"}},
+				},
+				Message: "Internal Server Error",
+			},
+			rateLimit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRateLimitError(tt.err)
+			if result != tt.rateLimit {
+				t.Errorf("isRateLimitError() = %v, want %v for error: %v", result, tt.rateLimit, tt.err)
+			}
+		})
+	}
 }
 
 func Test_extractOsArch(t *testing.T) {


### PR DESCRIPTION
Transient GitHub API errors (401, 403, 5xx) during provider cache reload no longer permanently blacklist valid releases. Rate limit errors still abort the reload to avoid wasting API calls. Adds isTransientError and isRateLimitError helpers with tests.